### PR TITLE
fix(browserSync): Issue #4 update usage of connect-history-api-fallback to work with v1.0.0

### DIFF
--- a/src/tasks/browserSync.js
+++ b/src/tasks/browserSync.js
@@ -11,10 +11,11 @@ class BrowserSyncTask {
 			throw new Error('BrowserSyncTask: config is missing from configuration!');
 		}
 
-		if (!_isUndefined(this.options.historyApiFallback)) {
+		if (!_isUndefined(this.options.historyApiFallback) && this.options.historyApiFallback !== false) {
 			this.options.config.server = _merge({}, this.options.config.server);
 			this.options.config.server.middleware = _merge([], this.options.config.server.middleware);
-			this.options.config.server.middleware.push(historyApiFallback);
+			var historyApiFallbackConfig = _merge({}, this.options.historyApiFallback);
+			this.options.config.server.middleware.push(historyApiFallback(historyApiFallbackConfig));
 		}
 
 		return this;


### PR DESCRIPTION
connect-history-api-fallback is now a callback that takes a configuration object.
- You can now use historyApiFallback option as an object to config connect-history-api-fallback.
- If historyApiFallback is set to true it passes an empty object and uses defaults.
- If historyApiFallback is false it will no longer try to use connect-history-api-fallback.
