### PR TITLE
add jsHintOptions parameter to enable passing options

### DIFF
--- a/src/tasks/jshint.js
+++ b/src/tasks/jshint.js
@@ -17,7 +17,7 @@ class JshintTask {
 		let options = this.options;
 		gulp.task(options.taskName, options.taskDeps, () => {
 			return gulp.src(options.src)
-				.pipe(jshint())
+				.pipe(jshint(options.jsHintOptions))
 				.pipe(jshint.reporter(stylish))
 		});
 	}


### PR DESCRIPTION
add jsHintOptions parameter to enable passing options according to JSHint at http://jshint.com/docs/options/

usage: example:

``` javascript
    /*
     * ... some definitions
     */

    taskMaker.defineTask('jshint', {
        taskName: 'lint',
        src: path.source,
        jsHintOptions: {
            esnext: true
        }
    });
```
