### PR TITLE
remove gulp-cache and gulp-changed from sass task

### DIFF
--- a/src/tasks/sass.js
+++ b/src/tasks/sass.js
@@ -1,7 +1,5 @@
 import plumber from 'gulp-plumber';
 import sass from 'gulp-sass';
-import cache from 'gulp-cached';
-import changed from 'gulp-changed';
 import sourcemaps from 'gulp-sourcemaps';
 import _isUndefined from 'lodash/lang/isUndefined';
 import _merge from 'lodash/object/merge';
@@ -32,9 +30,7 @@ class SassTask {
 		let options = this.options;
 		gulp.task(options.taskName, options.taskDeps, () => {
 			let chain = gulp.src(options.src)
-				.pipe(cache(options.taskName))
 				.pipe(plumber(options.plumberOptions))
-				.pipe(changed(options.dest, {extension: '.css'}))
 				.pipe(sourcemaps.init())
 				.pipe(sass(options.config))
 				.pipe(sourcemaps.write('.'))


### PR DESCRIPTION
`gulp-cache` and `gulp-changed` from sass task need to be removed due to lack of support for many to one ( \* => 1 ) items, such as in `sass/scss`, where there are files which imports other files and etc.

In the current state, files are not refreshed in the following (common) scenario where:
style.scss:

``` scss
    @import "someOtherFile"
    .div-a {
    }

    .div-b {
    }
```

_someOtherFile.scss

``` scss
    .div-c {
    }

    .div-d {
    }
```

if changes occurs in file `_someOtherFile.scss`, even though `watch` event is being triggered and re-compilation of `sass` files is starting - `sass` task doesn't do anything because it caches and track-changes _only_ style.scss.

Hence, until further working solution, it is preferred to be removed for now (and maybe cause a bit of an overhead of a few more milliseconds)
