### PR TITLE
add browser sync setting so source-maps would not trigger a page refresh

### DIFF
--- a/src/tasks/sass.js
+++ b/src/tasks/sass.js
@@ -37,7 +37,7 @@ class SassTask {
 				.pipe(gulp.dest(options.dest));
 
 			_forEach(options.globalBrowserSyncs, (bs) => {
-				chain = chain.pipe(bs.stream());
+				chain = chain.pipe(bs.stream({match: '**/*.css'}));
 			});
 
 			return chain;


### PR DESCRIPTION
Usually when working in development mode, we're using `scss`/`sass` source-maps. Generating those source-maps triggers `browser-sync` to refresh the entire page instead of just pushing the new `style.css` changes.
This setting fixes it
