### PR TITLE
adding chmod for tasks which output files

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,9 @@ taskMaker.defineTask(NAME_OF_GULPHELPERS_TASK, OPTIONS);
 The named gulp-helper task will be loaded via `require` and you pass options into it. There is a whole bunch of tasks already defined, [take a look](https://github.com/lookfirst/gulp-helpers/tree/master/src/tasks) at the ones you need in order to figure out the options you can pass in. I've tried to keep the naming pretty consistent between tasks. For example, `src` and `dest` will always map to the arguments to `gulp.src()` and `gulp.dest()`.
 
 There are a couple options which are default across all tasks:
-* `taskName` - the name of the `gulp.task()` task, defaults to the first argument of `defineTask` (String)
-* `taskDeps` - passed into `gulp.task()` as the dependent tasks (Array)
+* `taskName` - The name of the `gulp.task()` task, defaults to the first argument of `defineTask` (String)
+* `taskDeps` - Passed into `gulp.task()` as the dependent tasks (Array)
+* `chmod` - For tasks which output files (such as `sass`, `copy`, `concat`...), since version `2.0.15`, it is capable of setting `read/write` permissions (Number or Object). See [gulp-chmod](https://github.com/sindresorhus/gulp-chmod) for more details.
 
 ### situation
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-helpers",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "description": "A set of tasks and helpers for gulp",
   "main": "dist/index.js",
   "license": "MIT",

--- a/src/tasks/babel.js
+++ b/src/tasks/babel.js
@@ -8,6 +8,7 @@ import to5 from 'gulp-babel';
 import uglify from 'gulp-uglify';
 import ngAnnotate from 'gulp-ng-annotate';
 import rename from 'gulp-rename';
+import chmod from 'gulp-chmod';
 import _isUndefined from 'lodash/lang/isUndefined';
 import _merge from 'lodash/object/merge';
 import _forEach from 'lodash/collection/forEach';
@@ -77,6 +78,10 @@ class BabelTask {
 
 			if (options.uglify) {
 				chain = chain.pipe(uglify(options.uglifyOptions));
+			}
+
+			if (!_isUndefined(options.chmod)) {
+				chain = chain.pipe(chmod(options.chmod));
 			}
 
 			chain = chain.pipe(sourcemaps.write('.'))

--- a/src/tasks/concat.js
+++ b/src/tasks/concat.js
@@ -3,6 +3,7 @@ import cache from 'gulp-cached';
 import concat from 'gulp-concat';
 import replace from 'gulp-replace-task';
 import sourcemaps from 'gulp-sourcemaps';
+import chmod from 'gulp-chmod';
 import _isUndefined from 'lodash/lang/isUndefined';
 
 class ConcatTask {
@@ -42,6 +43,10 @@ class ConcatTask {
 
 			if (options.sourcemaps) {
 				chain = chain.pipe(sourcemaps.write());
+			}
+
+			if (!_isUndefined(options.chmod)) {
+				chain = chain.pipe(chmod(options.chmod));
 			}
 
 			chain = chain.pipe(gulp.dest(options.dest));

--- a/src/tasks/copy.js
+++ b/src/tasks/copy.js
@@ -3,6 +3,7 @@ import cache from 'gulp-cached';
 import changed from 'gulp-changed';
 import rename from 'gulp-rename';
 import replace from 'gulp-replace-task';
+import chmod from 'gulp-chmod';
 import _isUndefined from 'lodash/lang/isUndefined';
 import _forEach from 'lodash/collection/forEach';
 
@@ -38,6 +39,10 @@ class CopyTask {
 
 			if (options.rename) {
 				chain = chain.pipe(rename(options.rename));
+			}
+
+			if (!_isUndefined(options.chmod)) {
+				chain = chain.pipe(chmod(options.chmod));
 			}
 
 			chain = chain.pipe(gulp.dest(options.dest));

--- a/src/tasks/htmlMinify.js
+++ b/src/tasks/htmlMinify.js
@@ -1,5 +1,6 @@
 import htmlMin from 'gulp-minify-html';
 import plumber from 'gulp-plumber';
+import chmod from 'gulp-chmod';
 import _isUndefined from 'lodash/lang/isUndefined';
 import _merge from 'lodash/object/merge';
 
@@ -27,10 +28,17 @@ class HtmlMinifyTask {
 	defineTask(gulp) {
 		let options = this.options;
 		gulp.task(options.taskName, options.taskDeps, () => {
-			return gulp.src(options.src)
+			let chain = gulp.src(options.src)
 				.pipe(plumber())
-				.pipe(htmlMin(options.minimize))
-				.pipe(gulp.dest(options.dest))
+				.pipe(htmlMin(options.minimize));
+
+			if (!_isUndefined(options.chmod)) {
+				chain = chain.pipe(chmod(options.chmod));
+			}
+
+			chain = chain.pipe(gulp.dest(options.dest));
+
+			return chain;
 		});
 	}
 }

--- a/src/tasks/less.js
+++ b/src/tasks/less.js
@@ -9,6 +9,7 @@ import less from 'gulp-less';
 import lessDependents from 'gulp-less-dependents';
 import cache from 'gulp-cached';
 import sourcemaps from 'gulp-sourcemaps';
+import chmod from 'gulp-chmod';
 import lessPluginCleanCSS from 'less-plugin-clean-css';
 
 let cleancss = new lessPluginCleanCSS({advanced: true});
@@ -58,9 +59,11 @@ class LessTask {
 				chain = chain.pipe(sourcemaps.write('.', options.sourcemapOptions));
 			}
 
-			chain = chain
-					.pipe(gulp.dest(options.dest))
-					.pipe(filter(['*', '!*.css.map']));
+			if (!_isUndefined(options.chmod)) {
+				chain = chain.pipe(chmod(options.chmod));
+			}
+
+			chain = chain.pipe(gulp.dest(options.dest)).pipe(filter(['*', '!*.css.map']));
 
 			_forEach(options.globalBrowserSyncs, (bs) => {
 				chain = chain.pipe(bs.stream());

--- a/src/tasks/minify.js
+++ b/src/tasks/minify.js
@@ -1,6 +1,7 @@
 import sourcemaps from 'gulp-sourcemaps';
 import uglify from 'gulp-uglify';
 import plumber from 'gulp-plumber';
+import chmod from 'gulp-chmod';
 import _isUndefined from 'lodash/lang/isUndefined';
 import _merge from 'lodash/object/merge';
 
@@ -28,12 +29,18 @@ class MinifyTask {
 	defineTask(gulp) {
 		let options = this.options;
 		gulp.task(options.taskName, options.taskDeps, () => {
-			return gulp.src(options.src)
+			let chain = gulp.src(options.src)
 				.pipe(plumber())
 				.pipe(sourcemaps.init({loadMaps: true}))
 				.pipe(uglify(options.uglifyOptions))
-				.pipe(sourcemaps.write('.'))
-				.pipe(gulp.dest(options.dest))
+				.pipe(sourcemaps.write('.'));
+			if (!_isUndefined(options.chmod)) {
+				chain = chain.pipe(chmod(options.chmod));
+			}
+
+			chain = chain.pipe(gulp.dest(options.dest));
+
+			return chain;
 		});
 	}
 }

--- a/src/tasks/ngHtml2Js.js
+++ b/src/tasks/ngHtml2Js.js
@@ -6,6 +6,7 @@ import uglify from 'gulp-uglify';
 import htmlMin from 'gulp-minify-html';
 import ngHtml2Js from 'gulp-ng-html2js';
 import insert from 'gulp-insert';
+import chmod from 'gulp-chmod';
 import _isUndefined from 'lodash/lang/isUndefined';
 import _merge from 'lodash/object/merge';
 import _forEach from 'lodash/collection/forEach';
@@ -59,6 +60,10 @@ class NgHtml2JsTask {
 
 			if (options.uglify) {
 				chain = chain.pipe(uglify(options.uglifyOptions));
+			}
+
+			if (!_isUndefined(options.chmod)) {
+				chain = chain.pipe(chmod(options.chmod));
 			}
 
 			chain = chain.pipe(gulp.dest(options.dest));

--- a/src/tasks/sass.js
+++ b/src/tasks/sass.js
@@ -1,6 +1,7 @@
 import plumber from 'gulp-plumber';
 import sass from 'gulp-sass';
 import sourcemaps from 'gulp-sourcemaps';
+import chmod from 'gulp-chmod';
 import _isUndefined from 'lodash/lang/isUndefined';
 import _merge from 'lodash/object/merge';
 import _forEach from 'lodash/collection/forEach';
@@ -33,8 +34,11 @@ class SassTask {
 				.pipe(plumber(options.plumberOptions))
 				.pipe(sourcemaps.init())
 				.pipe(sass(options.config))
-				.pipe(sourcemaps.write('.'))
-				.pipe(gulp.dest(options.dest));
+				.pipe(sourcemaps.write('.'));
+			if (!_isUndefined(options.chmod)) {
+				chain = chain.pipe(chmod(options.chmod));
+			}
+			chain = chain.pipe(gulp.dest(options.dest));
 
 			_forEach(options.globalBrowserSyncs, (bs) => {
 				chain = chain.pipe(bs.stream({match: '**/*.css'}));


### PR DESCRIPTION
For tasks which output files (such as `sass`, `copy`, `concat`...), since version `2.0.15`, it is capable of setting `read/write` permissions (Number or Object)
