### PR TITLE
adding more options to eslint task

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-helpers",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "description": "A set of tasks and helpers for gulp",
   "main": "dist/index.js",
   "license": "MIT",

--- a/src/tasks/eslint.js
+++ b/src/tasks/eslint.js
@@ -5,6 +5,10 @@ class EslintTask {
 	setOptions(options) {
 		this.options = options;
 
+		if (this.options.failOnError && this.options.failAfterError) {
+			throw new Error('EslintTask: Please choose either failOnError or failAfterError option!');
+		}
+
 		if (_isUndefined(this.options.src)) {
 			throw new Error('EslintTask: src is missing from configuration!');
 		}
@@ -15,9 +19,29 @@ class EslintTask {
 	defineTask(gulp) {
 		let options = this.options;
 		gulp.task(options.taskName, options.taskDeps, () => {
-			return gulp.src(options.src)
-				.pipe(eslint())
-				.pipe(eslint.format())
+
+			var chain = gulp.src(options.src).pipe(eslint());
+
+			if (options.quiet) {
+				chain = chain.pipe(eslint.format((reports) => {
+					reports.forEach((report) => {
+						report.messages = report.messages.filter((message) => {
+							return message.fatal || message.severity > 1;
+						});
+					});
+					return '( *** Eslint runs in quite mode *** )';
+				}));
+			}
+
+			chain = chain.pipe(eslint.format());
+
+			if (options.failOnError) {
+				chain = chain.pipe(eslint.failOnError());
+			} else if (options.failAfterError) {
+				chain = chain.pipe(eslint.failAfterError());
+			}
+
+			return chain;
 		});
 	}
 }


### PR DESCRIPTION
the following `eslint` options were added, accoring to [gulp-eslint](https://www.npmjs.com/package/gulp-eslint) :
1. quiet mode 
2. failOnError
3. failAfterError
