### PR TITLE
fix backwards compatibility issue #22

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-helpers",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "A set of tasks and helpers for gulp",
   "main": "dist/index.js",
   "license": "MIT",
@@ -32,6 +32,7 @@
     "babel": "^5.8.29",
     "babel-runtime": "^5.8.29",
     "browser-sync": "^2.9.12",
+    "connect-history-api-fallback": "^1.1.0",
     "del": "^2.0.2",
     "express-history-api-fallback": "^2.0.0",
     "gulp-babel": "^5.3.0",

--- a/src/tasks/browserSync.js
+++ b/src/tasks/browserSync.js
@@ -1,8 +1,10 @@
 import _isArray from 'lodash/lang/isArray';
 import _isString from 'lodash/lang/isString';
 import _isUndefined from 'lodash/lang/isUndefined';
+import _isBoolean from 'lodash/lang/isBoolean';
 import _merge from 'lodash/object/merge';
-import historyApiFallback from 'express-history-api-fallback';
+import expressHistoryApiFallback from 'express-history-api-fallback';
+import connectHistoryApiFallback from 'connect-history-api-fallback';
 
 class BrowserSyncTask {
 	setOptions(options) {
@@ -17,14 +19,24 @@ class BrowserSyncTask {
 			this.options.config.server.middleware = _merge([], this.options.config.server.middleware);
 
 			let historyApiFallbackConfig;
+			let useExpress = false;
 			if (_isArray(this.options.historyApiFallback)) {
 				historyApiFallbackConfig = this.options.historyApiFallback;
+				useExpress = true;
 			} else if (_isString(this.options.historyApiFallback)) {
 				historyApiFallbackConfig = [this.options.historyApiFallback];
+				useExpress = true;
+			} else if (_isBoolean(this.options.historyApiFallback)) {
+				historyApiFallbackConfig = _merge({}, this.options.historyApiFallback);
 			} else {
 				throw new Error('BrowserSyncTask: historyApiFallback must be an absolute file path string or an Express Response.sendFile arguments array');
 			}
-			this.options.config.server.middleware.push(historyApiFallback(...historyApiFallbackConfig));
+			if(useExpress) {
+				this.options.config.server.middleware.push(expressHistoryApiFallback(...historyApiFallbackConfig));
+			}
+			else {
+				this.options.config.server.middleware.push(connectHistoryApiFallback(historyApiFallbackConfig));
+			}
 		}
 
 		return this;


### PR DESCRIPTION
In this fix, the parameter `historyApiFallback` of `browserSync` task can be either `boolean` which will be using `connect-history-api-fallback`, or a `string` or `array` which will be using `express-history-api-fallback` as described in #21 
