### PR TITLE
add gulp-css-usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-helpers",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "A set of tasks and helpers for gulp",
   "main": "dist/index.js",
   "license": "MIT",
@@ -41,6 +41,7 @@
     "gulp-chmod": "^1.3.0",
     "gulp-coffee": "^2.3.1",
     "gulp-concat": "^2.6.0",
+    "gulp-css-usage": "^1.0.8",
     "gulp-eslint": "^1.1.1",
     "gulp-filter": "^3.0.1",
     "gulp-htmlmin": "^1.3.0",

--- a/src/tasks/cssUsage.js
+++ b/src/tasks/cssUsage.js
@@ -1,0 +1,28 @@
+import plumber from 'gulp-plumber';
+import cssUsage from 'gulp-css-usage';
+import _isUndefined from 'lodash/lang/isUndefined';
+
+class CssUsageTask {
+	setOptions(options) {
+		this.options = options;
+
+		if (_isUndefined(this.options.src)) {
+			throw new Error('CssUsageTask: src is missing from configuration!');
+		}
+
+		if (_isUndefined(this.options.css)) {
+			throw new Error('CssUsageTask: css is missing from configuration!');
+		}
+
+		return this;
+	}
+
+	defineTask(gulp) {
+		let {taskName, taskDeps, src, css, babylon} = this.options;
+		gulp.task(taskName, taskDeps, () => {
+			return gulp.src(src).pipe(plumber()).pipe(cssUsage({css, babylon}));
+		});
+	}
+}
+
+module.exports = CssUsageTask;


### PR DESCRIPTION
this plug-in checks the css coverage for needless CSS selectors. it also
scan React's JSX files as well as other JS class frameworks
